### PR TITLE
Add option to specify an output dir

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,6 +56,11 @@ module.exports = function(grunt) {
         },
         src: ['tmp/international.txt']
       },
+      override_output_location: {
+        options: { encoding: 'utf8', algorithm: 'sha1', length: 4 },
+        src: ['tmp/override.txt'],
+        dest:"tmp/override/"
+      },
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ grunt.initConfig({
 })
 ```
 
+#### Specifying an output directory
+This allows you to specify where you'd like the renamed file to be copied.
+
+```js
+grunt.initConfig({
+  rev: {
+    files: {
+      src: ['scripts/*.js']
+    },
+    dest: 'build/output/'
+  }
+})
+```
+Note that when overriding the output directory the original file is left intact.
+
 #### Custom Options
 Change the algorithm or length to style the generated asset file names. Note that the `usemin` companion task requires at least one anycase hexadecimal character to prefix the file name.
 

--- a/tasks/rev.js
+++ b/tasks/rev.js
@@ -28,17 +28,25 @@ module.exports = function(grunt) {
       algorithm: 'md5',
       length: 8
     });
-
+    var dest = this.data.dest;
+    
     this.files.forEach(function(filePair) {
       filePair.src.forEach(function(f) {
-
         var hash = md5(f, options.algorithm, 'hex', options.encoding),
           prefix = hash.slice(0, options.length),
           renamed = [prefix, path.basename(f)].join('.'),
-          outPath = path.resolve(path.dirname(f), renamed);
-
+          outPath = path.resolve( dest || path.dirname(f), renamed);
+          
         grunt.verbose.ok().ok(hash);
-        fs.renameSync(f, outPath);
+        
+        // If a destination dir has been specified, copy the file to the new location rather than renaming
+        if ( dest ) {
+          fs.mkdirSync(dest);
+          fs.createReadStream(f).pipe(fs.createWriteStream(outPath));
+        } else {
+          fs.renameSync(f, outPath);
+        }
+        
         grunt.log.write(f + ' ').ok(renamed);
 
       });

--- a/test/fixtures/override.txt
+++ b/test/fixtures/override.txt
@@ -1,0 +1,1 @@
+The lazy dog is jumped over by the quick brown fox

--- a/test/rev_test.js
+++ b/test/rev_test.js
@@ -50,5 +50,14 @@ exports.rev = {
     test.ok(exists, '8 character MD5 hash prefix for international content');
 
     test.done();
+  },
+  different_output_dir: function(test) {
+    test.expect(3);
+
+    test.ok( grunt.file.exists('tmp/override.txt'), 'Source file still exists when using a different output dir');
+    test.ok( !grunt.file.exists('tmp/c409.override.txt'), 'Correctly absent in default location');
+    test.ok( grunt.file.exists('tmp/override/c409.override.txt'), 'Correctly present in overridden location');
+
+    test.done();
   }
 };


### PR DESCRIPTION
Hi,

Thanks for sharing this project, really useful.

I've got a complex build with a lot of different artifacts, a few different processing steps, so it's hard to use simple globbing patterns (*.js) to manage them. It makes my config a lot simpler if grunt-rev supports the ability to specify an output directory... hence the pull request.

Tests and linting are passing, I think I've stuck to the same style, and I've added an example to the README. Let me know what you think, any suggested edits, etc.
