### PR TITLE
Added an option to create a summary file (fix #6)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,6 +56,12 @@ module.exports = function(grunt) {
         },
         src: ['tmp/international.txt']
       },
+      summary_options: {
+        options: {
+          summary: 'tmp/rev_summary.js'
+        },
+        src: ['tmp/revsummary.txt']
+      }
     },
 
     // Unit tests.

--- a/tasks/rev.js
+++ b/tasks/rev.js
@@ -28,6 +28,7 @@ module.exports = function(grunt) {
       algorithm: 'md5',
       length: 8
     });
+    var summary = {};
 
     this.files.forEach(function(filePair) {
       filePair.src.forEach(function(f) {
@@ -36,7 +37,7 @@ module.exports = function(grunt) {
           prefix = hash.slice(0, options.length),
           renamed = [prefix, path.basename(f)].join('.'),
           outPath = path.resolve(path.dirname(f), renamed);
-
+        summary[f] = path.join(path.dirname(f), renamed);
         grunt.verbose.ok().ok(hash);
         fs.renameSync(f, outPath);
         grunt.log.write(f + ' ').ok(renamed);
@@ -44,6 +45,9 @@ module.exports = function(grunt) {
       });
     });
 
+    if (options.summary) {
+      grunt.file.write(options.summary, JSON.stringify(summary));
+    }
   });
 
 };

--- a/test/fixtures/revsummary.txt
+++ b/test/fixtures/revsummary.txt
@@ -1,0 +1,1 @@
+The quick brown fox jumps over the lazy dog

--- a/test/rev_test.js
+++ b/test/rev_test.js
@@ -50,5 +50,15 @@ exports.rev = {
     test.ok(exists, '8 character MD5 hash prefix for international content');
 
     test.done();
+  },
+  rev_summary_options: function(test) {
+    test.expect(2);
+
+    var exists = grunt.file.exists('tmp/rev_summary.js');
+    test.ok(exists, 'summary file produced');
+
+    var summary = grunt.file.readJSON('tmp/rev_summary.js');
+    test.equal(summary['tmp/revsummary.txt'], 'tmp/9e107d9d.revsummary.txt');
+    test.done();
   }
 };


### PR DESCRIPTION
As described this produce a summary file (i.e. file -> revved file map).
