### PR TITLE
suffix/postfix naming

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Default value: `'md5'`
 Type: `Number`
 Default value: `8`
 
-The number of characters of the file content hash to prefix the file name with.
+The number of characters of the file content hash to suffix the file name with.
 
 ### Usage Examples
 
 #### Basic Asset Revving
-This will rename `app.js` and `app.css` with an 8 character long hash prefix. For example `js/9becff3a.app.js` and `css/ae35dd05.app.css`. The hash value depends on the file contents.
+This will rename `app.js` and `app.css` with an 8 character long hash suffix. For example `js/app.9becff3a.js` and `css/app.ae35dd05.css`. The hash value depends on the file contents.
 
 ```js
 grunt.initConfig({
@@ -86,7 +86,7 @@ grunt.initConfig({
 ```
 
 #### Custom Options
-Change the algorithm or length to style the generated asset file names. Note that the `usemin` companion task requires at least one anycase hexadecimal character to prefix the file name.
+Change the algorithm or length to style the generated asset file names. Note that the `usemin` companion task requires at least one anycase hexadecimal character to suffix the file name.
 
 ```js
 grunt.initConfig({

--- a/tasks/rev.js
+++ b/tasks/rev.js
@@ -33,8 +33,9 @@ module.exports = function(grunt) {
       filePair.src.forEach(function(f) {
 
         var hash = md5(f, options.algorithm, 'hex', options.encoding),
-          prefix = hash.slice(0, options.length),
-          renamed = [prefix, path.basename(f)].join('.'),
+          suffix = hash.slice(0, options.length),
+          ext = path.extname(f),
+          renamed = [path.basename(f, ext), suffix, ext.slice(1)].join('.'),
           outPath = path.resolve(path.dirname(f), renamed);
 
         grunt.verbose.ok().ok(hash);

--- a/test/rev_test.js
+++ b/test/rev_test.js
@@ -30,24 +30,24 @@ exports.rev = {
   default_options: function(test) {
     test.expect(1);
 
-    var exists = grunt.file.exists('tmp/9e107d9d.default.txt');
-    test.ok(exists, '8 character MD5 hash prefix');
+    var exists = grunt.file.exists('tmp/default.9e107d9d.txt');
+    test.ok(exists, '8 character MD5 hash suffix');
 
     test.done();
   },
   custom_options: function(test) {
     test.expect(1);
 
-    var exists = grunt.file.exists('tmp/2fd4.custom.txt');
-    test.ok(exists, '4 character SHA-1 hash prefix');
+    var exists = grunt.file.exists('tmp/custom.2fd4.txt');
+    test.ok(exists, '4 character SHA-1 hash suffix');
 
     test.done();
   },
   international_options: function(test) {
     test.expect(1);
 
-    var exists = grunt.file.exists('tmp/faa07745.international.txt');
-    test.ok(exists, '8 character MD5 hash prefix for international content');
+    var exists = grunt.file.exists('tmp/international.faa07745.txt');
+    test.ok(exists, '8 character MD5 hash suffix for international content');
 
     test.done();
   }


### PR DESCRIPTION
This adds suffix/postfix naming support as described in #2.

Note: to avoid breaking compatibility with yeoman/grunt-usemin, please do not accept this pull request until yeoman/grunt-usemin#113 has been merged into the v2.0 branch _and_ the v2.0 branch has been merged into master.
