### PR TITLE
After callback, passing mapping object

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,6 +56,14 @@ module.exports = function(grunt) {
         },
         src: ['tmp/international.txt']
       },
+      mapping: {
+        options: {
+          after: function (mapping, options) {
+            grunt.file.write('tmp/mapping.json', JSON.stringify(mapping));
+          }
+        },
+        src: ['tmp/mapping.txt', 'tmp/international.txt']
+      },
     },
 
     // Unit tests.

--- a/tasks/rev.js
+++ b/tasks/rev.js
@@ -13,6 +13,7 @@ var fs = require('fs'),
   crypto = require('crypto');
 
 module.exports = function(grunt) {
+  var _ = grunt.util._;
 
   function md5(filepath, algorithm, encoding, fileEncoding) {
     var hash = crypto.createHash(algorithm);
@@ -27,7 +28,8 @@ module.exports = function(grunt) {
       encoding: 'utf8',
       algorithm: 'md5',
       length: 8
-    });
+    }),
+    mapping = {};
 
     this.files.forEach(function(filePair) {
       filePair.src.forEach(function(f) {
@@ -35,13 +37,18 @@ module.exports = function(grunt) {
         var hash = md5(f, options.algorithm, 'hex', options.encoding),
           prefix = hash.slice(0, options.length),
           renamed = [prefix, path.basename(f)].join('.'),
-          outPath = path.resolve(path.dirname(f), renamed);
+          outPath = path.join(path.dirname(f), renamed);
 
+        mapping[f] = outPath;
         grunt.verbose.ok().ok(hash);
         fs.renameSync(f, outPath);
         grunt.log.write(f + ' ').ok(renamed);
 
       });
+
+      if (_.isFunction(options.after)) {
+        options.after(mapping, options);
+      }
     });
 
   });

--- a/test/rev_test.js
+++ b/test/rev_test.js
@@ -50,5 +50,13 @@ exports.rev = {
     test.ok(exists, '8 character MD5 hash prefix for international content');
 
     test.done();
+  },
+  mapping: function(test) {
+    test.expect(1);
+
+    var raw = grunt.file.read('tmp/mapping.json');
+    test.equal(raw, '{"tmp/mapping.txt":"tmp/d41d8cd9.mapping.txt"}');
+
+    test.done();
   }
 };


### PR DESCRIPTION
I added the ability to call a function and pass it mapping. This will flexible ways to manage output file and to fully own output format.

``` coffeescript
rev:
  options:
    after: (dirs, mapping, options) ->
      output = {}
      for oldPath, newPath of mapping
        output[path.basename oldPath] = newPath.replace dirs.webapp, ""
      grunt.file.write path.join(dirs.resources, "assetsMap.json"), JSON.stringify(output)
```
