### PR TITLE
Added separator option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,8 @@ module.exports = function(grunt) {
       custom_options: {
         options: {
           algorithm: 'sha1',
-          length: 4
+          length: 4,
+          separator: '-'
         },
         src: ['tmp/custom.txt']
       },

--- a/tasks/rev.js
+++ b/tasks/rev.js
@@ -26,7 +26,8 @@ module.exports = function(grunt) {
     var options = this.options({
       encoding: 'utf8',
       algorithm: 'md5',
-      length: 8
+      length: 8,
+      separator: '.'
     });
 
     this.files.forEach(function(filePair) {
@@ -34,7 +35,7 @@ module.exports = function(grunt) {
 
         var hash = md5(f, options.algorithm, 'hex', options.encoding),
           prefix = hash.slice(0, options.length),
-          renamed = [prefix, path.basename(f)].join('.'),
+          renamed = [prefix, path.basename(f)].join(options.separator),
           outPath = path.resolve(path.dirname(f), renamed);
 
         grunt.verbose.ok().ok(hash);

--- a/test/rev_test.js
+++ b/test/rev_test.js
@@ -38,7 +38,7 @@ exports.rev = {
   custom_options: function(test) {
     test.expect(1);
 
-    var exists = grunt.file.exists('tmp/2fd4.custom.txt');
+    var exists = grunt.file.exists('tmp/2fd4-custom.txt');
     test.ok(exists, '4 character SHA-1 hash prefix');
 
     test.done();


### PR DESCRIPTION
I had one really annoying problem when using `grunt-rev` together with `grunt-contrib-compress` and gzip compression.

I configured my compress task to change file extensions of gzip compressed files to `.css.gz` using the `ext` option:

```
{
  expand: true,
  cwd: 'dist/htdocs/',
  dest: 'dist/htdocs/',
  src: ['**/*.css'],
  ext: '.css.gz' 
}
```

Everything fine - almost. Except that 
my `59c28e95.test.css` was renamed to `59c28e95.css.gz`
my `17575a8d.vendor.css` was renamed to `17575a8d.css.gz`
etc.

I know it's probably a "bug" in compress or in the grunt (or even node) file reader/writer/glob but nevertheless I added an optional `separator` option so you can at least workaround this problem by having your files renamed to `59c28e95-test.css` instead of `59c28e95.test.css` for example (dash instead of dot).

Merge it if you like :)

PS: I know I could have just flipped the execution order of the compress and the rev task but it seemed like a more "reliable" way doing it that way ;)
