### PR TITLE
[IMPROVEMENT] Fix for Issue #30

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ node_js:
   - "0.9"
   - "0.10"
 before_script:
-  - npm install -g npm@">=2.0.0"
+  - npm update -q
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.9"
   - "0.10"
-  - npm-v2.0.0
 before_script:
   - npm update -q
+  - npm --version
+  - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
+  - "0.8"
   - "0.9"
-npm:
-  - "2.0.0"
+  - "0.10"
 before_script:
+  - npm install -g npm@">=2.0.0"
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "0.8"
+  - "0.9"
 before_script:
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - "0.8"
   - "0.9"
   - "0.10"
+  - npm-v2.0.0
 before_script:
   - npm update -q
-  - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - "0.9"
+npm:
+  - "2.0.0"
 before_script:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
   ],
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.9.0"
+    "node": ">= 0.10.0"
   },
   "scripts": {
     "test": "grunt test"
   },
   "devDependencies": {
     "grunt-contrib-copy": ">=0.8.0",
-    "grunt-contrib-jshint": ">=0.1.1",
-    "grunt-contrib-clean": ">=0.4.0",
-    "grunt-contrib-nodeunit": ">=0.1.2",
+    "grunt-contrib-jshint": ">=0.11.1",
+    "grunt-contrib-clean": ">=0.6.0",
+    "grunt-contrib-nodeunit": ">=0.4.1",
     "grunt": ">=0.4.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "grunt-contrib-jshint": "0.1.1rc6",
     "grunt-contrib-clean": "0.4.0rc6",
     "grunt-contrib-nodeunit": "0.1.2rc6",
-    "grunt": "0.4.0rc6"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-copy": "0.4.0",
-    "grunt-contrib-jshint": "0.1.1rc6",
-    "grunt-contrib-clean": "0.4.0rc6",
-    "grunt-contrib-nodeunit": "0.1.2rc6",
+    "grunt-contrib-copy": ">=0.8.0",
+    "grunt-contrib-jshint": ">=0.1.1",
+    "grunt-contrib-clean": ">=0.4.0",
+    "grunt-contrib-nodeunit": ">=0.1.2",
     "grunt": ">=0.4.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.9.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-rev",
   "description": "Static file asset revisioning through content hashing",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/cbas/grunt-rev",
   "author": {
     "name": "Sebastiaan Deckers",

--- a/tasks/rev.js
+++ b/tasks/rev.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
   function md5(filepath, algorithm, encoding, fileEncoding) {
     var hash = crypto.createHash(algorithm);
     grunt.log.verbose.write('Hashing ' + filepath + '...');
-    hash.update(fs.readFileSync(filepath), fileEncoding);
+    hash.update(fs.readFileSync(filepath, fileEncoding));
     return hash.digest(encoding);
   }
 

--- a/tasks/rev.js
+++ b/tasks/rev.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
         fsOptions = {encoding: fileEncoding};
 
     grunt.log.verbose.write('Hashing ' + filepath + '...');
-    hash.update(fs.readFileSync(filepath, fsOptions), fileEncoding));
+    hash.update(fs.readFileSync(filepath, fsOptions), fileEncoding);
     return hash.digest(encoding);
   }
 

--- a/tasks/rev.js
+++ b/tasks/rev.js
@@ -15,9 +15,11 @@ var fs = require('fs'),
 module.exports = function(grunt) {
 
   function md5(filepath, algorithm, encoding, fileEncoding) {
-    var hash = crypto.createHash(algorithm);
+    var hash      = crypto.createHash(algorithm),
+        fsOptions = {encoding: fileEncoding};
+
     grunt.log.verbose.write('Hashing ' + filepath + '...');
-    hash.update(fs.readFileSync(filepath, fileEncoding));
+    hash.update(fs.readFileSync(filepath, fsOptions), fileEncoding));
     return hash.digest(encoding);
   }
 

--- a/tasks/rev.js
+++ b/tasks/rev.js
@@ -17,7 +17,7 @@ module.exports = function(grunt) {
   function md5(filepath, algorithm, encoding, fileEncoding) {
     var hash = crypto.createHash(algorithm);
     grunt.log.verbose.write('Hashing ' + filepath + '...');
-    hash.update(grunt.file.read(filepath), fileEncoding);
+    hash.update(fs.readFileSync(filepath), fileEncoding);
     return hash.digest(encoding);
   }
 


### PR DESCRIPTION
#### **Problem/BUG** => _hash for big files was not correctly calculated_

The `fs` library is already included and it looks like it works better than `grunt.file`.

With files bigger than few kilobytes the hash is now calculated in the right way.
It looks like `grunt.file.read` either does not read the file correctly or not in full.

This change solves Issue #30
